### PR TITLE
Various improvements to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get --yes install python3 python3-pip python3-pillow python3-cairo pytho
 # and install it. To be able to do this, the source code has to be cloned outside the container, 
 # since it is a private repository.
 
-FROM builder as compile-vinga
+FROM builder AS compile-vinga
 RUN --mount=type=bind,source=jutge-vinga,target=/root/jutge-vinga,readwrite \
     make -C /root/jutge-vinga/src && \
     cp /root/jutge-vinga/src/jutge-vinga /usr/local/bin/jutge-vinga && \
@@ -48,7 +48,7 @@ RUN echo "worker ALL=(ALL) NOPASSWD: /usr/local/bin/jutge-vinga" | \
     (sudo su -c 'EDITOR="tee -a" visudo -f /etc/sudoers.d/worker')
 
 # Download vinga from the last version uploaded
-FROM builder as download-vinga
+FROM builder AS download-vinga
 
 RUN wget -O /usr/local/bin/jutge-vinga https://github.com/jutge-org/jutge-vinga-bin/raw/master/jutge-vinga-linux
 RUN chown root:root /usr/local/bin/jutge-vinga

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-all: lite server full
-
-%:
-	docker build -t jutge.org:$* --build-arg type=$* .
-
-.PHONY: all
+-all: lite server full
++all: server full lite
+ 
+ %:
+-       docker build -t jutge.org:$* --build-arg type=$* .
++       docker build -t jutge-$* --build-arg type=$* .
+ 
+ .PHONY: all

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 You need to have [Docker](https://docker.io) installed.
 
-There are 3 different images:
+There are 3 different images you can compile using the same Dockerfile:
 
 | name     | BaseSystem | Compilers | LaTeX |
 | -------- | ---------- | --------- | ----- |
@@ -12,17 +12,27 @@ There are 3 different images:
 
 Use `make` to build all images or `make full|lite|server` to build only one of them.
 
-#### Old README
+## Building manually
 
-The old README, which documented the judging process is now at [the masterplan repository](https://github.com/jutge-org/masterplan/blob/main/docs/jutge-dockerfile.README.md).
+This image has two optional build arguments: `type` and `vinga`
 
+- `type` may be one of `lite`, `server` or `full`. Defaults to server
+- `vinga` may be one of `compile-vinga` or `download-vinga` to compile vinga from the source or to download it if you do not have access to the source. Defaults to compile-vinga
+
+You may pass build arguments to the docker build process using `--build-arg type=server` or `--build-arg vinga=download-vinga`.
+
+## Usage
+
+Starting the correction process requires from the host machine works best with `jutge-run` from [Jutge  Server Toolkit](https://github.com/jutge-org/jutge-server-toolkit)
+
+For more information on how to create and acquire the required files for a correction, check out the problem
+documentation on [Jutge Toolkit](https://github.com/jutge-org/jutge-toolkit/blob/master/README.md)
 
 ## Credits
 
 - [Jordi Petit](https://github.com/jordi-petit)
 - [Jordi Reig](https://github.com/jordireig)
 - [Pau Fernández](https://github.com/pauek)
-- [Carlos Martín](https://github.com/Witixin1512)
 
 ## License
 


### PR DESCRIPTION
This pull request:

- Allows Docker to cache the common part of the differently flavoured images.
- Adds an option to download a pre-compiled version of vinga.
- Documents the new flags and link to the toolkit documentation for a basic guide on how to get started with running the correction process.