### PR TITLE
Shave storage space by using apt --no-install-recommends in Dockerfiles.

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -6,12 +6,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get --yes update && apt-get --yes upgrade
 
 # Set local timezone
-RUN apt-get --yes install tzdata && \
+RUN apt-get --yes --no-install-recommends install tzdata && \
     ln -fs /usr/share/zoneinfo/Europe/Madrid /etc/localtime && \
     dpkg-reconfigure --frontend noninteractive tzdata
 
 # Install initial tools
-RUN apt-get --yes install \
+RUN apt-get --yes --no-install-recommends install \
     tzdata ack moreutils less tree adduser curl wget joe nano sudo unzip jq
 
 # Ubuntu images now include a default user 'ubuntu' (UID:GID 1000:1000).
@@ -28,10 +28,10 @@ RUN for i in $(seq 1 9); do \
 	done
 
 # Install Python3
-RUN apt-get --yes install python3 python3-pip python3-venv 
+RUN apt-get --yes --no-install-recommends install python3 python3-pip python3-venv 
 
 # NOTE(pauek): Needed by the jutge driver!
-RUN apt-get --yes install python3-yaml python3-chardet
+RUN apt-get --yes --no-install-recommends install python3-yaml python3-chardet
 RUN pip3 install --break-system-packages yogi
 
 # Install jutge-vinga from another container (which we just use to depend on it here)

--- a/Dockerfile.cpp
+++ b/Dockerfile.cpp
@@ -1,4 +1,4 @@
 FROM jutgeorg/base:latest
 USER root
-RUN apt install -y clang gcc g++
+RUN apt install --no-install-recommends -y clang gcc g++
 USER worker

--- a/Dockerfile.esoteric
+++ b/Dockerfile.esoteric
@@ -1,23 +1,24 @@
 FROM jutgeorg/base:latest
 USER root
-RUN apt update && apt --yes install beef
-RUN apt update && apt --yes install basic256 bwbasic
-RUN apt update && apt --yes install chicken-bin libchicken-dev guile-2.2 stalin
-RUN apt update && apt --yes install clisp
-RUN apt update && apt --yes install erlang
-RUN apt update && apt --yes install f2c gfortran 
-RUN apt update && apt --yes install fpc
-RUN apt update && apt --yes install swi-prolog
-RUN apt update && apt --yes install gdc
-RUN apt update && apt --yes install gnat
-RUN apt update && apt --yes install gobjc
+RUN apt update && apt --yes --no-install-recommends install beef
+RUN apt update && apt --yes --no-install-recommends install basic256 bwbasic
+RUN apt update && apt --yes --no-install-recommends install chicken-bin libchicken-dev guile-2.2 stalin
+RUN apt update && apt --yes --no-install-recommends install clisp
+RUN apt update && apt --yes --no-install-recommends install erlang
+RUN apt update && apt --yes --no-install-recommends install f2c gfortran 
+RUN apt update && apt --yes --no-install-recommends install fpc
+RUN apt update && apt --yes --no-install-recommends install swi-prolog
+RUN apt update && apt --yes --no-install-recommends install gdc
+RUN apt update && apt --yes --no-install-recommends install gnat
+RUN apt update && apt --yes --no-install-recommends install gobjc
 
 # Crystal
 ADD https://dist.crystal-lang.org/apt/setup.sh /root/install-crystal.sh
+RUN apt update && apt --yes --no-install-recommends install gnupg
 RUN bash /root/install-crystal.sh
 RUN rm /root/install-crystal.sh
 # The above lines only add crystal to an apt repository
-RUN apt install --yes crystal 
+RUN apt install --yes --no-install-recommends crystal 
 
 # Julia
 #ADD https://install.julialang.org /root/install-julia.sh

--- a/Dockerfile.extra
+++ b/Dockerfile.extra
@@ -2,6 +2,7 @@ FROM jutgeorg/base:latest
 USER root
 
 # Zig
+RUN apt update && apt --yes --no-install-recommends install xz-utils
 RUN curl https://ziglang.org/download/index.json \
 	| jq '.["master"]["x86_64-linux"]["tarball"]' | tr -d '"'  \
 	| xargs wget && \
@@ -15,18 +16,19 @@ ENV PATH="$PATH:/opt/zig"
 USER worker
 RUN curl -fsSL https://bun.sh/install | bash && \
 	mv ~/.bun /opt/bun
+	
 USER root
 RUN echo 'export PATH=$PATH:/opt/bun/bin' > /etc/profile.d/99-bun.sh
 
 # Install extra languages
-RUN apt-get --yes install php-cli
-RUN apt-get --yes install rustc
-RUN apt-get --yes install lua5.3
-RUN apt-get --yes install gccgo golang
-RUN apt-get --yes install r-base r-base-core r-base-dev r-cran-vgam r-recommended
+RUN apt-get --yes --no-install-recommends install php-cli
+RUN apt-get --yes --no-install-recommends install rustc
+RUN apt-get --yes --no-install-recommends install lua5.3
+RUN apt-get --yes --no-install-recommends install gccgo golang
+RUN apt-get --yes --no-install-recommends install r-base r-base-core r-base-dev r-cran-vgam r-recommended
 
-RUN apt-get --yes install nodejs
-# RUN apt-get --yes install ruby
+RUN apt-get --yes --no-install-recommends install nodejs
+# RUN apt-get --yes --no-install-recommends install ruby
 
 
 # Whitespace

--- a/Dockerfile.haskell
+++ b/Dockerfile.haskell
@@ -1,4 +1,4 @@
 FROM jutgeorg/base:latest
 USER root
-RUN apt install -y ghc
+RUN apt install -y --no-install-recommends ghc
 USER worker

--- a/Dockerfile.java
+++ b/Dockerfile.java
@@ -1,11 +1,11 @@
 FROM jutgeorg/base:latest
 USER root
-RUN apt update && apt --yes install openjdk-17-jdk-headless
+RUN apt update && apt --yes --no-install-recommends install openjdk-17-jdk-headless
 
-RUN apt update && apt --yes install kotlin
+RUN apt update && apt --yes --no-install-recommends install kotlin
 
 # Required for clj to work
-RUN apt --yes install rlwrap
+RUN apt --yes --no-install-recommends install rlwrap
 ADD https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh /root/install-clojure.sh
 RUN bash /root/install-clojure.sh
 
@@ -16,7 +16,7 @@ WORKDIR /clojure
 RUN echo '{:paths ["src"]}' > deps.edn
 RUN mkdir src
 RUN echo '(ns core)\n\n(println "Hello, World")' > src/core.clj
-RUN clj -M
+RUN clj -M 
 RUN mv /root/.m2/repository/ /clojure/.m2
 
 RUN chmod -R o+r /clojure/

--- a/Dockerfile.latex
+++ b/Dockerfile.latex
@@ -1,4 +1,4 @@
 FROM jutgeorg/base:latest
 USER root
-RUN apt-get --yes install texlive-latex-extra texlive-games texlive-pstricks
+RUN apt-get --yes --no-install-recommends install texlive-latex-extra texlive-games texlive-pstricks
 USER worker

--- a/Dockerfile.python
+++ b/Dockerfile.python
@@ -1,14 +1,14 @@
-FROM jutgeorg/base:latest
+FROM jutgeorg/cpp:latest
 USER root
 RUN pip3 install --break-system-packages turtle-pil easyinput yogi pytokr mypy pycodestyle
 
+RUN apt update && apt --yes --no-install-recommends install zlib1g-dev
 # Codon (as root)
 ADD https://exaloop.io/install.sh /root/install-codon.sh
 # FIXME: Why install-codon.sh does not return 0?
 RUN bash /root/install-codon.sh || true
 RUN mv /root/.codon /opt/codon && \
     ln -s /opt/codon/bin/codon /usr/local/bin/codon
-
 # Install Python libraries (as user worker!)
 USER worker
 RUN mkdir /opt/pylibs && \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TAG := $(shell date +%s)
 all: $(IMAGES)
 
 cpp: base
-python: base
+python: cpp
 latex: base
 extra: base
 java: base


### PR DESCRIPTION
This pull request also makes the Python image depend on the C++ one, in order for Codon to already have the binaries it needs for native compilation accessible, which proved to occupy less space in disk than if downloading `g++` in the Python image.